### PR TITLE
switch over to MS mapit

### DIFF
--- a/web/register/views.py
+++ b/web/register/views.py
@@ -1,4 +1,5 @@
 from django.views.generic import TemplateView, View
+from django.conf import settings
 from django.core import serializers
 from django.contrib.gis.geos import Polygon
 from django.shortcuts import redirect
@@ -15,9 +16,9 @@ class MapView(TemplateView):
         if 'postcode' in request.GET:
             try:
                 req = requests.get(
-                    "http://mapit.democracyclub.org.uk/postcode/{}".format(
+                    "http://mapit.mysociety.org/postcode/{}".format(
                         request.GET['postcode']
-                    ))
+                    ), headers=settings.MAPIT_HEADERS)
                 in_london = False
                 for area_id, area in req.json()['areas'].items():
                     if area['type'] == "LBW":

--- a/web/web/settings/base.py
+++ b/web/web/settings/base.py
@@ -118,6 +118,7 @@ MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 # CELERY_RESULT_BACKEND='djcelery.backends.database:DatabaseBackend'
 # CELERY_RESULT_BACKEND='djcelery.backends.database:DatabaseBackend'
 BROKER_URL = 'redis://localhost:6379/0'
+MAPIT_KEY = None
 
 
 # .local.py overrides all the common settings.
@@ -125,6 +126,11 @@ try:
     from .local import *
 except ImportError:
     pass
+
+
+MAPIT_HEADERS = {}
+if MAPIT_KEY:
+    MAPIT_HEADERS['X-Api-Key'] = MAPIT_KEY
 
 
 # --SELECT rw.area, rw.gss, rw.name, rw.population, rw.population_voting_age, rw.population_young, --borough_id, rw.registered_count, rw.percent_registered

--- a/web/yournumber/views.py
+++ b/web/yournumber/views.py
@@ -1,6 +1,7 @@
 import requests
 
 from django.views.generic import TemplateView, FormView, RedirectView
+from django.conf import settings
 from django.core.urlresolvers import reverse
 
 from register.models import RegisteredPerson, Ward, Borough, LLSOA
@@ -25,9 +26,9 @@ class BaseDataView(object):
             data['borough'] = area_info.borough
         else:
             req = requests.get(
-                "http://mapit.democracyclub.org.uk/postcode/{}".format(
+                "http://mapit.mysociety.org/postcode/{}".format(
                     postcode
-                ))
+                ), headers=settings.MAPIT_HEADERS)
             for area_id, area in req.json()['areas'].items():
                 if area['type'] == "LBW":
                     try:


### PR DESCRIPTION
If we cared about this more, I'd have bothered to factor out the base URL into a constant and stuff... but we don't.

This switches over to using the mysociety mapit. If you want to give it an API key, you can add a statement

`MAPIT_KEY = 'foo'`

to `local.py` when you deploy it and it will get passed through in the request headers. There is a key you can use in s3://zappa-electionleaflets-eu-west-1/production_secrets.json which we use on leaflets.

If you don't bother putting that setting in `local.py`, the app will be limited to 50 calls per day. I'll leave it to you to deploy as appropriate.